### PR TITLE
Homepage: Move getQuestions actions into constructor #20

### DIFF
--- a/client/src/components/homepage/Homepage.js
+++ b/client/src/components/homepage/Homepage.js
@@ -5,7 +5,9 @@ import {connect} from "react-redux";
 import {getQuestions} from "../../actions/questionActions";
 
 class Homepage extends Component {
-    componentDidMount() {
+    constructor(props) {
+        super(props);
+
         this.props.getQuestions();
     }
 


### PR DESCRIPTION
Homepage component was sometimes rendering without data due to getQuestions action being called in componentDidMount instead of a contractor. 

- moved getQuestions action into constructor
- removed componentDidMount